### PR TITLE
Turn on realistic train acceleration model

### DIFF
--- a/openttd.cfg
+++ b/openttd.cfg
@@ -79,7 +79,7 @@ amount_of_rivers = 2
 
 [vehicle]
 road_side = left
-train_acceleration_model = 0
+train_acceleration_model = 1
 roadveh_acceleration_model = 0
 train_slope_steepness = 3
 roadveh_slope_steepness = 5


### PR DESCRIPTION
The realistic acceleration for trains setting turns on a simple physics-based acceleration model. Depending on the weight of the train, the power of the engine and the gradient of the slope it's going up or down, the acceleration is changed. This is more realistic than the original TTD's interpretation, but it's not perfect. 

For building railway tracks this has the following consequences:

- Really sharp corners are punished a lot. 90-degree curves have a speedlimit of 61 km/h, two successive 45-degree curves in the same direction get limited to 88 km/h.
- For softer curves, the speedlimit is calculated from the number of direction changes along the length of the train, among others.
- Depots and stations have speedlimits.
- Small slopes don't affect the speed by much
- A heavy train with a weak engine might not reach the engine's max speed because of all the friction. Multi-engine trains help. 

The speedlimits are multiplied by a factor of 1.5 for monorails and 2 for maglevs.